### PR TITLE
[Task] Add initial skills and placement policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,6 @@ This section is for project-level custom commands, rules, or environment-specifi
 
 ## 7. Skills
 
-- 共通Skillsは `skills/` に配置する
+- 共通スキルは `skills/` に配置する
 - リポジトリ固有の最適化は `.agents/skills` に追加する
-- 各Skillは「目的 / 入力 / 出力 / 手順 / 必要なコマンド」を明記する
+- 各スキルは「目的 / 入力 / 出力 / 手順 / 必要なコマンド」を明記する

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ gh issue create --title "[Task] テンプレ動作確認" --body "テンプレ�
 - [docs/LABELS.md](docs/LABELS.md): ラベルの定義と標準
 - [AGENTS.md](AGENTS.md): AIエージェントのための行動指針
 - [docs/PROMPTS.md](docs/PROMPTS.md): プロンプト置き場（雛形）
-- `skills/`: 共通Skills（リポジトリ固有の最適化は `.agents/skills`）
+- `skills/`: 共通スキル（リポジトリ固有の最適化は `.agents/skills`）
 
 ---
 

--- a/skills/change-summary/SKILL.md
+++ b/skills/change-summary/SKILL.md
@@ -21,5 +21,10 @@ Summarize changes clearly and state impact and follow-up needs.
 - git: inspect diffs/history (e.g., `git diff`, `git log`)
 - gh: review PR diff if needed
 
+## Example commands
+- `git diff main...HEAD`
+- `git log --oneline -5`
+- `gh pr diff <number>`
+
 ## Notes
 - Prefer meaningful grouping over raw lists.

--- a/skills/issue-creation/SKILL.md
+++ b/skills/issue-creation/SKILL.md
@@ -24,5 +24,8 @@ Draft a clear issue with Goal/Scope/Acceptance Criteria so AI can implement it.
 - gh: create issue if needed (e.g., `gh issue create`)
 - git: not required in most cases
 
+## Example commands
+- `gh issue create --title \"[Task] <title>\" --body \"<body>\"`
+
 ## Notes
 - Always include Out-of-scope items to prevent scope creep.

--- a/skills/pr-explanation/SKILL.md
+++ b/skills/pr-explanation/SKILL.md
@@ -24,5 +24,9 @@ Explain the PR intent and scope to make review efficient.
 - gh: view PR details if needed (e.g., `gh pr view`, `gh pr diff`)
 - git: review local diffs if needed
 
+## Example commands
+- `gh pr view <number>`
+- `gh pr diff <number>`
+
 ## Notes
 - Optimize for fast reader comprehension.

--- a/skills/pr-review/SKILL.md
+++ b/skills/pr-review/SKILL.md
@@ -23,5 +23,9 @@ Review a PR to identify risks, bugs, and scope drift early.
 - gh: view PR details if needed (e.g., `gh pr view`, `gh pr diff`)
 - git: review diffs if needed
 
+## Example commands
+- `gh pr diff <number>`
+- `git diff main...HEAD`
+
 ## Notes
 - Base findings on evidence; label speculation clearly.

--- a/skills/problem-investigation/SKILL.md
+++ b/skills/problem-investigation/SKILL.md
@@ -24,6 +24,11 @@ Clarify reproduction, hypothesize root causes, and define impact and next invest
 - git: inspect history (e.g., `git log`, `git blame`)
 - gh: review issue/PR context if needed
 
+## Example commands
+- `rg \"error\" -n`
+- `git blame <path>`
+- `gh issue view <number>`
+
 ## Notes
 - Clearly label speculation and pair it with a verification method.
 - If the task is investigation-only, do not modify files.

--- a/skills/status-check/SKILL.md
+++ b/skills/status-check/SKILL.md
@@ -21,6 +21,12 @@ Provide a clear, concise snapshot of work status and the next actions.
 - git: check status/history (e.g., `git status`, `git log`)
 - gh: view issues/PRs if needed (e.g., `gh issue view`, `gh pr view`)
 
+## Example commands
+- `git status -sb`
+- `git log -1 --oneline`
+- `gh issue view <number>`
+- `gh pr view <number>`
+
 ## Notes
 - Separate facts from assumptions.
 - Mark out-of-scope suggestions explicitly as proposals.


### PR DESCRIPTION
## Related Issue
- Closes #14

## What (What was implemented)
- Added initial skills under `skills/` with purpose/input/output/steps/required commands
- Documented skills placement policy in `AGENTS.md` and `README.md`

## Why (Why this change is needed)
- Provide a ready-to-use skill set for the template
- Clarify where common vs repo-specific skills should live

## Scope (In / Out)
**In:**
- New `skills/` entries for the initial skill set
- Policy note in `AGENTS.md` and `README.md`

**Out:**
- Changes to workflow rules, CI, or dependencies

## How to test

### AI-side checks (performed by author / AI)
- Verified files exist under `skills/`
- Confirmed policy text present in `AGENTS.md` and `README.md`

### Human-side checks (to be performed locally)
- Open each `skills/*/SKILL.md` and confirm clarity and consistency

## Notes / Implementation details
- Skill instructions are in English with explicit "respond in Japanese" output guidance

## Screenshots / Logs (optional)
- N/A

## Checklist
- [x] 対象 Issue の Goal / Acceptance Criteria をすべて満たしている
- [x] Issue に書かれていない機能を先取りしていない
- [x] 入出力仕様（パス・ファイル名）が Issue と一致している
- [x] エラー時のログが分かりやすい
- [x] 依存追加が最小限である
- [x] README / ドキュメント更新の要否を確認した
